### PR TITLE
adds xml-rpc serializing and deserialzing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # serde-llsd
-Serialization library for Linden Lab Serial Data format. Rust/Serde version.
+
+Serialization library for Linden Lab Serial Data format, and xlm-rpc. Rust/Serde version.
 
 Linden Lab Structured Data (LLSD) serialization
 
-This is a serialization system used by Second Life and Open Simulator. 
+This is a serialization system used by Second Life and Open Simulator.
 It is documented here: http://wiki.secondlife.com/wiki/LLSD
 
 ## Introduction
@@ -12,9 +13,8 @@ There are three formats - XML, binary, and "Notation". All store
 the same data, which is roughly the same as what JSON can represent.
 Parsing and output functions are provided.
 
-
-
 ## Status
+
 XML, binary, and Notation versions are implemented.
 
 Unit tests pass. Tested against Second Life asset servers and Open Simulator servers.
@@ -31,9 +31,9 @@ Used by the Sharpview metaverse viewer.
 - URI - Rust String that is a URI
 - Binary - Vec<u8>
 
-- A map is a HashMap mapping String keys to LLSD values. 
+- A map is a HashMap mapping String keys to LLSD values.
 
-- An array is a Rust Vec of LLSD values. 
+- An array is a Rust Vec of LLSD values.
 
 ## Field access
 
@@ -41,8 +41,8 @@ The **enum_as_inner** crate is used to derive access functions for each field ty
 So, given an LLSDValue llsdval which is expected to be an Integer,
 
     let n = *llsdval.as_integer().unwrap();
-    
-will yield the integer value. 
+
+will yield the integer value.
 
 ## LLSD values in Rust
 
@@ -51,7 +51,7 @@ An LLSD value is a tree.
 
 ## Character sets
 
-Notation is divided into a byte stream form and a string from. 
+Notation is divided into a byte stream form and a string from.
 
 The byte stream form supports all the formats defined for LLSD, including
 byte-counted strings and binary values. Only single-byte ASCII characters are allowed.
@@ -63,8 +63,7 @@ Binary values must be in hex or Base64 format. String-form Notation can be place
 LLSD XML.
 
 ## Known problems.
+
 - "Notation" fomat input will not currently accept infinity or NaN values.
 
 - Error messages do not indicate the source of the problem in the incoming stream.
-
-

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -1,31 +1,45 @@
 //! #De-serialization. Converts an LLSD stream to tree of LLSDValue structs.
 pub mod binary;
-pub mod xml;
 pub mod notation;
+pub mod xml;
+pub mod xml_rpc;
 
 use anyhow::{anyhow, Error};
+
+use crate::de::xml_rpc::XMLRPCPREFIX;
 
 /// Parse LLSD, detecting format.
 /// Recognizes Notation, and XML LLSD with sentinels.
 /// Will accept leading whitespace.
 pub fn auto_from_str(msg_string: &str) -> Result<crate::LLSDValue, Error> {
-    let msg_string = msg_string.trim_start();   // remove leading whitespace
-    //  Try Notation sentinel. Tolerate missing newline at end of sentinel.
+    let msg_string = msg_string.trim_start(); // remove leading whitespace
+                                              //  Try Notation sentinel. Tolerate missing newline at end of sentinel.
     if let Some(stripped) = msg_string.strip_prefix(notation::LLSDNOTATIONSENTINEL.trim_end()) {
         return notation::from_str(stripped);
     }
     //  Try XML sentinel.
     if msg_string.starts_with(xml::LLSDXMLSENTINEL) {
-        // try XML
-        return xml::from_str(msg_string);
+        // try XML if it has an LLSDXML prefix
+        if msg_string.starts_with(xml::LLSDXMLPREFIX) {
+            return xml::from_str(msg_string);
+        }
+
+        // try XMLRPC if it has a XMLRPC prefix
+        if msg_string.starts_with(xml_rpc::XMLRPCPREFIX)
+            || msg_string.starts_with(xml_rpc::XMLRPCPREFIX2)
+            || msg_string.starts_with(xml_rpc::XMLRPCPREFIX3)
+        {
+            return xml_rpc::from_str(msg_string);
+        }
     }
+
     //  Trim string to N chars for error msg.
     let snippet = msg_string
         .chars()
         .zip(0..60)
         .map(|(c, _)| c)
         .collect::<String>();
-    Err(anyhow!("LLSD format not recognized: {:?}", snippet))
+    Err(anyhow!("XML format not recognized: {:?}", snippet))
 }
 
 /// Parse LLSD, detecting format.
@@ -39,22 +53,21 @@ pub fn auto_from_bytes(msg: &[u8]) -> Result<crate::LLSDValue, Error> {
     {
         return binary::from_bytes(&msg[binary::LLSDBINARYSENTINEL.len()..]);
     }
-    //  For text forms, tolerate leading whitespace.      
-    {   let msg = trim_ascii_start(msg);               // remove leading whitespace if any
-        //  Try Notation sentinel. Tolerate trailing newline. 
-        let sentinel = notation::LLSDNOTATIONSENTINEL.trim_end().as_bytes();  // sentinel without the trailing newline
-        if msg.len() >= sentinel.len()
-            && &msg[0..sentinel.len()] == sentinel
-        {
+    //  For text forms, tolerate leading whitespace.
+    {
+        let msg = trim_ascii_start(msg); // remove leading whitespace if any
+                                         //  Try Notation sentinel. Tolerate trailing newline.
+        let sentinel = notation::LLSDNOTATIONSENTINEL.trim_end().as_bytes(); // sentinel without the trailing newline
+        if msg.len() >= sentinel.len() && &msg[0..sentinel.len()] == sentinel {
             return notation::from_bytes(&msg[sentinel.len()..]);
         }
         //  Try XML sentinel.
         let msgstring = std::str::from_utf8(msg)?; // convert to UTF-8 string
         if msgstring.trim_start().starts_with(xml::LLSDXMLSENTINEL) {
-        // try XML
+            // try XML
             return xml::from_str(msgstring);
         }
-    }   
+    }
     //  Check for binary without header. If array or map marker, parse.
     if msg.len() > 1 {
         match msg[0] {
@@ -63,7 +76,7 @@ pub fn auto_from_bytes(msg: &[u8]) -> Result<crate::LLSDValue, Error> {
             _ => {}
         }
     }
-    
+
     //  Trim string to N chars for error msg.
     let snippet = String::from_utf8_lossy(msg)
         .chars()
@@ -73,7 +86,7 @@ pub fn auto_from_bytes(msg: &[u8]) -> Result<crate::LLSDValue, Error> {
     Err(anyhow!("LLSD format not recognized: {:?}", snippet))
 }
 
-/// Trim ASCII whitespace from string. 
+/// Trim ASCII whitespace from string.
 /// From an unstable Rust feature soon to become standard.
 fn trim_ascii_start(b: &[u8]) -> &[u8] {
     let mut bytes = b;
@@ -86,7 +99,6 @@ fn trim_ascii_start(b: &[u8]) -> &[u8] {
     }
     bytes
 }
-
 
 #[test]
 fn testpbrmaterialdecode() {
@@ -131,12 +143,12 @@ fn testnotationdetect1() {
 "#;
     let parsed_sa = auto_from_str(TESTNOTATION1A).unwrap();
     let parsed_sb = auto_from_str(TESTNOTATION1B).unwrap();
-    assert_eq!(parsed_sa, parsed_sb);              // must match, with and without trailing whitespace.
+    assert_eq!(parsed_sa, parsed_sb); // must match, with and without trailing whitespace.
     let s = crate::notation_to_string(&parsed_sa).unwrap();
-    assert_eq!(TESTNOTATION1A, s);                 // check round-trip
+    assert_eq!(TESTNOTATION1A, s); // check round-trip
     let parsed_ba = auto_from_bytes(TESTNOTATION1A.as_bytes()).unwrap();
     let parsed_bb = auto_from_bytes(TESTNOTATION1B.as_bytes()).unwrap();
-    assert_eq!(parsed_ba, parsed_bb);              // must match, with and without trailing whitespace.
-    ////let b = crate::notation_to_bytes(&parsed_ba).unwrap();
-    ////assert_eq!(TESTNOTATION1A.as_bytes(), b);         // must match correct form
+    assert_eq!(parsed_ba, parsed_bb); // must match, with and without trailing whitespace.
+                                      ////let b = crate::notation_to_bytes(&parsed_ba).unwrap();
+                                      ////assert_eq!(TESTNOTATION1A.as_bytes(), b);         // must match correct form
 }

--- a/src/de/xml.rs
+++ b/src/de/xml.rs
@@ -35,7 +35,7 @@ pub fn from_str(xmlstr: &str) -> Result<LLSDValue, Error> {
 ////let mut reader = Reader::from_str(xmlstr);
 
 /// Read XML from buffered source and parse into LLSDValue.
-pub fn from_reader<R: BufRead>(rdr: &mut R) -> Result<LLSDValue, Error> {
+fn from_reader<R: BufRead>(rdr: &mut R) -> Result<LLSDValue, Error> {
     let mut reader = Reader::from_reader(rdr); // create an XML reader from a sequential reader
     reader.trim_text(true); // do not want trailing blanks
     reader.expand_empty_elements(true); // want end tag events always
@@ -110,7 +110,7 @@ fn parse_value<R: BufRead>(
         "undef" | "real" | "integer" | "boolean" | "string" | "uri" | "binary" | "uuid"
         | "date" => parse_primitive_value(reader, starttag, attrs),
         "map" => parse_map(reader),
-        "array" => parse_array(reader),
+        "array" => parse_array(reader, parse_value),
         _ => Err(anyhow!(
             "Unknown data type <{}> at position {}",
             starttag,
@@ -201,7 +201,7 @@ fn parse_primitive_value<R: BufRead>(
 }
 
 //  Parse one map.
-fn parse_map<R: BufRead>(reader: &mut Reader<&mut R>) -> Result<LLSDValue, Error> {
+pub fn parse_map<R: BufRead>(reader: &mut Reader<&mut R>) -> Result<LLSDValue, Error> {
     //  Entered with a "map" start tag just parsed.
     let mut map: HashMap<String, LLSDValue> = HashMap::new(); // accumulating map
     let mut texts = Vec::new(); // accumulate text here
@@ -258,7 +258,9 @@ fn parse_map<R: BufRead>(reader: &mut Reader<&mut R>) -> Result<LLSDValue, Error
 
 //  Parse one map entry.
 //  Format <key> STRING </key> LLSDVALUE
-fn parse_map_entry<R: BufRead>(reader: &mut Reader<&mut R>) -> Result<(String, LLSDValue), Error> {
+pub fn parse_map_entry<R: BufRead>(
+    reader: &mut Reader<&mut R>,
+) -> Result<(String, LLSDValue), Error> {
     //  Entered with a "key" start tag just parsed.  Expecting text.
     let mut texts = Vec::new(); // accumulate text here
     let mut buf = Vec::new();
@@ -319,7 +321,11 @@ fn parse_map_entry<R: BufRead>(reader: &mut Reader<&mut R>) -> Result<(String, L
 }
 
 /// Parse one LLSD object. Recursive.
-fn parse_array<R: BufRead>(reader: &mut Reader<&mut R>) -> Result<LLSDValue, Error> {
+pub fn parse_array<R, F>(reader: &mut Reader<&mut R>, parse_value: F) -> Result<LLSDValue, Error>
+where
+    R: BufRead,
+    F: Fn(&mut Reader<&mut R>, &str, &Attributes) -> Result<LLSDValue, Error>,
+{
     //  Entered with an <array> tag just parsed.
     let mut texts = Vec::new(); // accumulate text here
     let mut buf = Vec::new();
@@ -373,7 +379,7 @@ fn parse_array<R: BufRead>(reader: &mut Reader<&mut R>) -> Result<LLSDValue, Err
 
 /// Parse binary object.
 /// Input in base64, base16, or base85.
-fn parse_binary(s: &str, attrs: &Attributes) -> Result<Vec<u8>, Error> {
+pub fn parse_binary(s: &str, attrs: &Attributes) -> Result<Vec<u8>, Error> {
     // "Parsers must support base64 encoding. Parsers may support base16 and base85."
     let encoding = match get_attr(attrs, b"encoding")? {
         Some(enc) => enc,
@@ -397,22 +403,22 @@ fn parse_binary(s: &str, attrs: &Attributes) -> Result<Vec<u8>, Error> {
 }
 
 /// Parse ISO 9660 date, simple form.
-fn parse_date(s: &str) -> Result<i64, Error> {
+pub fn parse_date(s: &str) -> Result<i64, Error> {
     Ok(chrono::DateTime::parse_from_rfc3339(s)?.timestamp())
 }
 
 /// Parse integer. LSL allows the empty string as 0.
-fn parse_integer(s: &str) -> Result<i32, Error> {
+pub fn parse_integer(s: &str) -> Result<i32, Error> {
     let s = s.trim();
     if s.is_empty() {
-        Ok(0)               // empty string
+        Ok(0) // empty string
     } else {
-        Ok(s.parse::<i32>()?)    // nonempty string
+        Ok(s.parse::<i32>()?) // nonempty string
     }
 }
 
 ///  Parse boolean. LSL allows 0. 0.0, false, 1. 1.0, true.
-fn parse_boolean(s: &str) -> Result<bool, Error> {
+pub fn parse_boolean(s: &str) -> Result<bool, Error> {
     Ok(match s {
         "0" | "0.0" => false,
         "1" | "1.0" => true,
@@ -439,7 +445,6 @@ fn get_attr(attrs: &Attributes, key: &[u8]) -> Result<Option<String>, Error> {
 
 #[test]
 fn xmlparsetest1() {
-
     const TESTXMLZERO: &str = r#"
 <?xml version="1.0" encoding="UTF-8"?>
 <llsd>
@@ -451,7 +456,7 @@ fn xmlparsetest1() {
 </llsd>
 "#;
 
-    const TESTXMLZEROARRAY: [i32;3] = [ 0, 100, 0 ]; // expected values
+    const TESTXMLZEROARRAY: [i32; 3] = [0, 100, 0]; // expected values
 
     const TESTXMLNAN: &str = r#"
 <?xml version="1.0" encoding="UTF-8"?>
@@ -527,12 +532,13 @@ fn xmlparsetest1() {
     trytestcase(TESTXML1);
     //  Special test cases.
     //  Test zero case, where an empty <integer /> is 0, per spec.
-    {   let parsed0 = from_str(TESTXMLZERO).unwrap();
+    {
+        let parsed0 = from_str(TESTXMLZERO).unwrap();
         println!("Parse of {}: \n{:#?}", TESTXMLZERO, parsed0);
-        let arr = parsed0.as_array().unwrap();  // yields array of LLSD values
-        assert_eq!(arr.len() , TESTXMLZEROARRAY.len()); // lengths must match
+        let arr = parsed0.as_array().unwrap(); // yields array of LLSD values
+        assert_eq!(arr.len(), TESTXMLZEROARRAY.len()); // lengths must match
         for (item, n) in arr.iter().zip(TESTXMLZEROARRAY) {
-            assert_eq!(n, *(item.as_integer().unwrap()));  // must match
+            assert_eq!(n, *(item.as_integer().unwrap())); // must match
         }
     }
     //  Test NAN case
@@ -546,6 +552,4 @@ fn xmlparsetest1() {
         let s2 = generated.replace(" ", "").replace("\n", "");
         assert_eq!(s1, s2);
     }
-
-    
 }

--- a/src/de/xml_rpc.rs
+++ b/src/de/xml_rpc.rs
@@ -1,0 +1,424 @@
+use crate::de::xml;
+//
+//  de/xml.rs -- XML-rpc deserializer for OpenSimulator's login
+//
+//  Library for serializing and de-serializing data in
+//  Linden Lab Structured Data format.
+//
+//  XML-rpc format.
+//
+//  Benthicllsd
+//  October, 2025.
+//  License: LGPL.
+//
+use crate::LLSDValue;
+use anyhow::{anyhow, Error};
+use quick_xml::events::attributes::Attributes;
+use quick_xml::events::Event;
+use quick_xml::Reader;
+use std::collections::HashMap;
+use std::io::{BufRead, BufReader};
+////use uuid;
+//
+//  Constants
+//
+//
+pub const XMLRPCPREFIX: &str = "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodResponse>";
+pub const XMLRPCPREFIX2: &str = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<methodResponse>";
+pub const XMLRPCPREFIX3: &str =
+    "<?xml version=\\\"1.0\\\" encoding=\\\"utf-8\\\"?><methodResponse>";
+///    Parse LLSD expressed in XML into an LLSD tree.
+pub fn from_str(xmlstr: &str) -> Result<LLSDValue, Error> {
+    // Unwrap the Result, returning early if it was an error
+    let parsed = from_reader(&mut BufReader::new(xmlstr.as_bytes()))?;
+    let flattened = flatten_login_response(parsed);
+    Ok(flattened)
+}
+fn flatten_login_response(value: LLSDValue) -> LLSDValue {
+    match value {
+        LLSDValue::Array(arr) => {
+            let mut merged = HashMap::new();
+            for v in arr {
+                if let LLSDValue::Map(m) = v {
+                    for (k, val) in m {
+                        merged.insert(k, val);
+                    }
+                }
+            }
+            LLSDValue::Map(merged)
+        }
+        _ => value,
+    }
+}
+/// Read XML from buffered source and parse into LLSDValue.
+fn from_reader<R: BufRead>(rdr: &mut R) -> Result<LLSDValue, Error>
+where
+    R: BufRead,
+{
+    let mut reader = Reader::from_reader(rdr); // create an XML reader from a sequential reader
+    reader.trim_text(true); // do not want trailing blanks
+    reader.expand_empty_elements(true); // want end tag events always
+    let mut buf = Vec::new(); // reader work area
+    let mut output: Option<LLSDValue> = None;
+    //  Outer parse. Find <llsd> and parse its interior.
+    loop {
+        match reader.read_event(&mut buf) {
+            Ok(Event::Start(ref e)) => {
+                match e.name() {
+                    b"methodResponse" => {
+                        if output.is_some() {
+                            return Err(anyhow!("More than one <methodResponse> block in data"));
+                        }
+                        let mut buf2 = Vec::new();
+                        match reader.read_event(&mut buf2) {
+                            Ok(Event::Start(ref e)) => {
+                                let tagname = std::str::from_utf8(e.name())?; // tag name as string to start parse
+                                                                              //  This does all the real work.
+                                output = Some(parse_value(&mut reader, tagname, &e.attributes())?);
+                            }
+                            _ => {
+                                return Err(anyhow!(
+                                    "Expected XMLRPC data, found {:?} error at position {}",
+                                    e.name(),
+                                    reader.buffer_position()
+                                ))
+                            }
+                        };
+                    }
+                    _ => {
+                        return Err(anyhow!(
+                            "Expected <methodResponse>, found {:?} error at position {}",
+                            e.name(),
+                            reader.buffer_position()
+                        ))
+                    }
+                }
+            }
+            Ok(Event::Text(_e)) => (), // Don't actually need random text
+            Ok(Event::End(ref _e)) => (), // Tag matching check is automatic.
+            Ok(Event::Eof) => break,   // exits the loop when reaching end of file
+            Err(e) => {
+                return Err(anyhow!(
+                    "Error at position {}: {:?}",
+                    reader.buffer_position(),
+                    e
+                ))
+            }
+            _ => (), // There are several other `Event`s we do not consider here
+        }
+
+        // if we don't keep a borrow elsewhere, we can clear the buffer to keep memory usage low
+        buf.clear()
+    }
+    //  Final result, if stored
+    match output {
+        Some(out) => Ok(out),
+        None => Err(anyhow!("Unexpected end of data, no <llsd> block.")),
+    }
+}
+/// Parse one value - real, integer, map, etc. Recursive.
+////fn parse_value<R: Read+BufRead>(rdr: &mut R) -> Result<LLSDValue, Error> {
+fn parse_value<R: BufRead>(
+    reader: &mut Reader<&mut R>,
+    starttag: &str,
+    attrs: &Attributes,
+) -> Result<LLSDValue, Error> {
+    //  Entered with a start tag alread parsed and in starttag
+    match starttag {
+        "undef" | "real" | "integer" | "boolean" | "string" | "uri" | "binary" | "uuid" | "i4"
+        | "date" => parse_primitive_value(reader, starttag, attrs),
+        "map" => xml::parse_map(reader),
+        "array" => xml::parse_array(reader, parse_value),
+        "params" | "param" | "value" | "struct" | "data" => parse_container(reader, starttag),
+        "member" => parse_member(reader),
+        _ => Err(anyhow!(
+            "Unknown data asdf type <{}> at position {}",
+            starttag,
+            reader.buffer_position()
+        )),
+    }
+}
+
+fn parse_container<R: BufRead>(
+    reader: &mut Reader<&mut R>,
+    end_tag: &str,
+) -> Result<LLSDValue, Error> {
+    let mut items = Vec::new();
+    let mut buf = Vec::new();
+
+    loop {
+        match reader.read_event(&mut buf) {
+            Ok(Event::Start(e)) => {
+                let tagname = std::str::from_utf8(e.name())?;
+                let val = parse_value(reader, tagname, &e.attributes())?;
+
+                if !matches!(val, LLSDValue::Array(ref arr) if arr.is_empty()) {
+                    items.push(val);
+                }
+            }
+            Ok(Event::End(e)) if e.name() == end_tag.as_bytes() => break,
+            Ok(Event::Text(_)) | Ok(Event::Comment(_)) => {}
+            Ok(Event::Eof) => return Err(anyhow!("Unexpected EOF while parsing <{}>", end_tag)),
+            Err(e) => {
+                return Err(anyhow!(
+                    "Parse error at {}: {:?}",
+                    reader.buffer_position(),
+                    e
+                ))
+            }
+            _ => {}
+        }
+        buf.clear();
+    }
+
+    if items.is_empty() {
+        Ok(LLSDValue::Array(vec![]))
+    } else if items.len() == 1 {
+        match &items[0] {
+            LLSDValue::Map(_) => Ok(items[0].clone()), // unwrap single map
+            other => Ok(other.clone()),
+        }
+    } else {
+        // multiple items
+        let mut merged_items = Vec::new();
+
+        for item in items {
+            match item {
+                LLSDValue::Array(arr) => {
+                    // if array contains only maps, merge into a single map
+                    if arr.iter().all(|v| matches!(v, LLSDValue::Map(_))) {
+                        let mut merged_map = HashMap::new();
+                        for v in arr {
+                            if let LLSDValue::Map(m) = v {
+                                for (k, val) in m {
+                                    merged_map.insert(k, val);
+                                }
+                            }
+                        }
+                        merged_items.push(LLSDValue::Map(merged_map));
+                    } else {
+                        merged_items.push(LLSDValue::Array(arr));
+                    }
+                }
+                LLSDValue::Map(_) => merged_items.push(item),
+                other => merged_items.push(other),
+            }
+        }
+
+        Ok(LLSDValue::Array(merged_items))
+    }
+}
+//  Parse one map.
+fn parse_member<R: BufRead>(reader: &mut Reader<&mut R>) -> Result<LLSDValue, Error> {
+    //  Entered with a "map" start tag just parsed.
+    let mut map: HashMap<String, LLSDValue> = HashMap::new(); // accumulating map
+    let mut texts = Vec::new(); // accumulate text here
+    let mut buf = Vec::new();
+    loop {
+        let event = reader.read_event(&mut buf);
+        match event {
+            Ok(Event::Start(ref e)) => {
+                let tagname = std::str::from_utf8(e.name())?; // tag name as string
+                match tagname {
+                    "name" => {
+                        let (k, v) = parse_member_entry(reader)?; // read one key/value pair
+                        let _dup = map.insert(k, v); // insert into map
+                                                     //  Duplicates are not errors, per LLSD spec.
+                    }
+                    _ => {
+                        return Err(anyhow!("Expected 'name' in map, found '{}'", tagname));
+                    }
+                }
+            }
+            Ok(Event::Text(e)) => texts.push(e.unescape_and_decode(reader)?),
+            Ok(Event::End(ref e)) => {
+                //  End of an XML tag. No text expected.
+                let tagname = std::str::from_utf8(e.name())?; // tag name as string
+                if "member" != tagname {
+                    return Err(anyhow!(
+                        "Unmatched XML tags: <{}> .. <{}>",
+                        "member",
+                        tagname
+                    ));
+                };
+                return Ok(LLSDValue::Map(map)); // done, valid result
+            }
+            Ok(Event::Eof) => {
+                return Err(anyhow!(
+                    "Unexpected end of data in map at position {}",
+                    reader.buffer_position()
+                ))
+            }
+            Ok(Event::Comment(_)) => {} // ignore comment
+            Err(e) => {
+                return Err(anyhow!(
+                    "Parse Error at position {}: {:?}",
+                    reader.buffer_position(),
+                    e
+                ))
+            }
+            _ => {
+                return Err(anyhow!(
+                    "Unexpected parse event {:?} at position {} while parsing map",
+                    event,
+                    reader.buffer_position(),
+                ))
+            }
+        }
+    }
+}
+
+//  Parse one map entry.
+//  Format <key> STRING </key> LLSDVALUE
+fn parse_member_entry<R: BufRead>(
+    reader: &mut Reader<&mut R>,
+) -> Result<(String, LLSDValue), Error> {
+    //  Entered with a "key" start tag just parsed.  Expecting text.
+    let mut texts = Vec::new(); // accumulate text here
+    let mut buf = Vec::new();
+    loop {
+        let event = reader.read_event(&mut buf);
+        match event {
+            Ok(Event::Start(ref e)) => {
+                let tagname = std::str::from_utf8(e.name())?; // tag name as string
+                return Err(anyhow!("Expected 'name' in map, found '{}'", tagname));
+            }
+            Ok(Event::Text(e)) => texts.push(e.unescape_and_decode(reader)?),
+            Ok(Event::End(ref e)) => {
+                //  End of an XML tag. Should be </key>
+                let tagname = std::str::from_utf8(e.name())?; // tag name as string
+                if "name" != tagname {
+                    return Err(anyhow!("Unmatched XML tags: <{}> .. <{}>", "name", tagname));
+                };
+                let mut buf = Vec::new();
+                let k = texts.join(" ").trim().to_string(); // the key
+                texts.clear();
+                match reader.read_event(&mut buf) {
+                    Ok(Event::Start(ref e)) => {
+                        let tagname = std::str::from_utf8(e.name())?; // tag name as string
+                        let v = parse_value(reader, tagname, &e.attributes())?; // parse next value
+                        return Ok((k, v)); // return key value pair
+                    }
+                    _ => {
+                        return Err(anyhow!(
+                            "Unexpected parse error at position {} while parsing map entry",
+                            reader.buffer_position()
+                        ))
+                    }
+                };
+            }
+            Ok(Event::Eof) => {
+                return Err(anyhow!(
+                    "Unexpected end of data at position {}",
+                    reader.buffer_position()
+                ))
+            }
+            Ok(Event::Comment(_)) => {} // ignore comment
+            Err(e) => {
+                return Err(anyhow!(
+                    "Parse Error at position {}: {:?}",
+                    reader.buffer_position(),
+                    e
+                ))
+            }
+            _ => {
+                return Err(anyhow!(
+                    "Unexpected parse event {:?} at position {} while parsing map entry",
+                    event,
+                    reader.buffer_position(),
+                ))
+            }
+        }
+    }
+}
+
+/// Parse one value - real, integer, map, etc. Recursive.
+fn parse_primitive_value<R: BufRead>(
+    reader: &mut Reader<&mut R>,
+    starttag: &str,
+    attrs: &Attributes,
+) -> Result<LLSDValue, Error> {
+    //  Entered with a start tag already parsed and in starttag
+    let mut texts = Vec::new(); // accumulate text here
+    let mut buf = Vec::new();
+    loop {
+        let event = reader.read_event(&mut buf);
+        match event {
+            Ok(Event::Text(e)) => texts.push(e.unescape_and_decode(reader)?),
+            Ok(Event::End(ref e)) => {
+                let tagname = std::str::from_utf8(e.name())?; // tag name as string
+                if starttag != tagname {
+                    return Err(anyhow!(
+                        "Unmatched XML tags: <{}> .. <{}>",
+                        starttag,
+                        tagname
+                    ));
+                };
+                //  End of an XML tag. Value is in text.
+                let text = texts.join(" ").trim().to_string(); // combine into one big string
+                texts.clear();
+                //  Parse the primitive types.
+                return match starttag {
+                    "undef" => Ok(LLSDValue::Undefined),
+                    "real" => Ok(LLSDValue::Real(
+                        if text.to_lowercase() == "nan" {
+                            "NaN".to_string()
+                        } else {
+                            text
+                        }
+                        .parse::<f64>()?,
+                    )),
+                    "integer" => Ok(LLSDValue::Integer(xml::parse_integer(&text)?)),
+                    "boolean" => Ok(LLSDValue::Boolean(xml::parse_boolean(&text)?)),
+                    "string" => match text.to_lowercase().as_str() {
+                        "true" => Ok(LLSDValue::Boolean(true)),
+                        "false" => Ok(LLSDValue::Boolean(false)),
+                        _ => {
+                            if let Ok(uuid) = uuid::Uuid::parse_str(&text) {
+                                Ok(LLSDValue::UUID(uuid))
+                            } else {
+                                Ok(LLSDValue::String(text))
+                            }
+                        }
+                    },
+                    "uri" => Ok(LLSDValue::String(text)),
+                    "uuid" => Ok(LLSDValue::UUID(if text.is_empty() {
+                        uuid::Uuid::nil()
+                    } else {
+                        uuid::Uuid::parse_str(&text)?
+                    })),
+                    "i4" => Ok(LLSDValue::Integer(xml::parse_integer(&text)?)),
+                    "date" => Ok(LLSDValue::Date(xml::parse_date(&text)?)),
+                    "binary" => Ok(LLSDValue::Binary(xml::parse_binary(&text, attrs)?)),
+                    _ => Err(anyhow!(
+                        "Unexpected primitive data type <{}> at position {}",
+                        starttag,
+                        reader.buffer_position()
+                    )),
+                };
+            }
+            Ok(Event::Eof) => {
+                return Err(anyhow!(
+                    "Unexpected end of data in primitive value at position {}",
+                    reader.buffer_position()
+                ))
+            }
+            Ok(Event::Comment(_)) => {} // ignore comment
+            Err(e) => {
+                return Err(anyhow!(
+                    "Parse Error at position {}: {:?}",
+                    reader.buffer_position(),
+                    e
+                ))
+            }
+            _ => {
+                return Err(anyhow!(
+                    "Unexpected parse event {:?} at position {} while parsing: {:?}",
+                    event,
+                    reader.buffer_position(),
+                    starttag
+                ))
+            }
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,20 +19,20 @@ pub mod ser;
 
 pub use crate::{
     de::{
-        auto_from_bytes, auto_from_str,
+        auto_from_bytes,
+        auto_from_str,
         binary::from_bytes as binary_from_bytes,
         binary::from_reader as binary_from_reader, // Name clash
-        xml::from_reader,
-        xml::from_str,
         notation::from_bytes as notation_from_bytes,
         notation::from_str as notation_from_str,
+        xml::from_str,
     },
     ser::{
         binary::to_bytes,
-        binary::to_writer as binary_to_writer, // Name clash
+        binary::to_writer as binary_to_writer,     // Name clash
+        notation::to_string as notation_to_string, // Name clash
         xml::to_string,
         xml::to_writer,
-        notation::to_string as notation_to_string, // Name clash
     },
 };
 

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -1,4 +1,5 @@
 //! # Serialization. Converts a tree of LLSDValue structs to an LLSD stream.
 pub mod binary;
-pub mod xml;
 pub mod notation;
+pub mod xml;
+pub mod xml_rpc;

--- a/src/ser/xml.rs
+++ b/src/ser/xml.rs
@@ -56,7 +56,7 @@ pub fn to_string(val: &LLSDValue, do_indent: bool) -> Result<String, Error> {
 }
 
 /// Generate one <TYPE> VALUE </TYPE> output. VALUE is recursive.
-fn generate_value<W: Write>(writer: &mut W, val: &LLSDValue, spaces: usize, indent: usize) {
+pub fn generate_value<W: Write>(writer: &mut W, val: &LLSDValue, spaces: usize, indent: usize) {
     //  Output a single tag
     fn tag<W: Write>(writer: &mut W, tag: &str, close: bool, indent: usize) {
         if indent > 0 {
@@ -133,7 +133,7 @@ fn generate_value<W: Write>(writer: &mut W, val: &LLSDValue, spaces: usize, inde
 }
 
 /// XML standard character escapes.
-fn xml_escape(unescaped: &str) -> String {
+pub fn xml_escape(unescaped: &str) -> String {
     let mut s = String::new();
     for ch in unescaped.chars() {
         match ch {

--- a/src/ser/xml_rpc.rs
+++ b/src/ser/xml_rpc.rs
@@ -1,0 +1,147 @@
+use crate::{ser::xml::xml_escape, LLSDValue};
+use anyhow::Error;
+use base64::Engine;
+use chrono::TimeZone;
+use std::io::Write;
+
+pub fn to_string(val: &LLSDValue, do_indent: bool, method_name: &str) -> Result<String, Error> {
+    let mut s: Vec<u8> = Vec::new();
+    to_writer_xmlrpc(&mut s, val, do_indent, method_name)?;
+    Ok(std::str::from_utf8(&s)?.to_string())
+}
+
+pub fn to_writer_xmlrpc<W: Write>(
+    writer: &mut W,
+    value: &LLSDValue,
+    do_indent: bool,
+    method_name: &str,
+) -> Result<(), Error> {
+    write!(writer, "<?xml version=\"1.0\"?>")?;
+
+    if do_indent {
+        writeln!(writer, "\n<methodCall>")?;
+        writeln!(
+            writer,
+            "    <methodName>{}</methodName>",
+            xml_escape(method_name)
+        )?;
+        writeln!(writer, "    <params>")?;
+        writeln!(writer, "        <param>")?;
+        writeln!(writer, "            <value>")?;
+    } else {
+        write!(
+            writer,
+            "<methodCall><methodName>{}</methodName><params><param><value>",
+            xml_escape(method_name)
+        )?;
+    }
+
+    // write actual value (e.g., struct/map)
+    generate_value_xmlrpc(writer, value, if do_indent { 4 } else { 0 }, 12, do_indent);
+
+    if do_indent {
+        writeln!(writer, "            </value>")?;
+        writeln!(writer, "        </param>")?;
+        writeln!(writer, "    </params>")?;
+        writeln!(writer, "</methodCall>")?;
+    } else {
+        write!(writer, "</value></param></params></methodCall>")?;
+    }
+
+    writer.flush()?;
+    Ok(())
+}
+
+fn generate_value_xmlrpc<W: Write>(
+    writer: &mut W,
+    val: &LLSDValue,
+    spaces: usize,
+    indent: usize,
+    do_indent: bool,
+) {
+    fn tag<W: Write>(writer: &mut W, tag: &str, close: bool, indent: usize, do_indent: bool) {
+        if do_indent && indent > 0 {
+            let _ = write!(writer, "{:1$}", " ", indent);
+        }
+        if do_indent {
+            let _ = writeln!(writer, "<{}{}>", if close { "/" } else { "" }, tag);
+        } else {
+            let _ = write!(writer, "<{}{}>", if close { "/" } else { "" }, tag);
+        }
+    }
+
+    fn tag_value<W: Write>(writer: &mut W, text: &str, indent: usize, do_indent: bool) {
+        if do_indent && indent > 0 {
+            let _ = write!(writer, "{:1$}", " ", indent);
+        }
+        if text.is_empty() {
+            if do_indent {
+                let _ = writeln!(writer, "<string />");
+            } else {
+                let _ = write!(writer, "<string />");
+            }
+        } else if do_indent {
+            let _ = writeln!(writer, "<string>{}</string>", xml_escape(text));
+        } else {
+            let _ = write!(writer, "<string>{}</string>", xml_escape(text));
+        }
+    }
+
+    match val {
+        LLSDValue::Map(v) => {
+            tag(writer, "struct", false, indent, do_indent);
+            for (key, value) in v {
+                tag(writer, "member", false, indent + spaces, do_indent);
+                if do_indent {
+                    let _ = writeln!(
+                        writer,
+                        "{:indent$}<name>{}</name>",
+                        "",
+                        xml_escape(key),
+                        indent = indent + spaces * 2
+                    );
+                } else {
+                    let _ = write!(writer, "<name>{}</name>", xml_escape(key));
+                }
+                tag(writer, "value", false, indent + spaces * 2, do_indent);
+                generate_value_xmlrpc(writer, value, spaces, indent + spaces * 3, do_indent);
+                tag(writer, "value", true, indent + spaces * 2, do_indent);
+                tag(writer, "member", true, indent + spaces, do_indent);
+            }
+            tag(writer, "struct", true, indent, do_indent);
+        }
+
+        LLSDValue::Array(v) => {
+            tag(writer, "array", false, indent, do_indent);
+            tag(writer, "data", false, indent + spaces, do_indent);
+            for value in v {
+                tag(writer, "value", false, indent + spaces * 2, do_indent);
+                generate_value_xmlrpc(writer, value, spaces, indent + spaces * 3, do_indent);
+                tag(writer, "value", true, indent + spaces * 2, do_indent);
+            }
+            tag(writer, "data", true, indent + spaces, do_indent);
+            tag(writer, "array", true, indent, do_indent);
+        }
+        _ => {
+            // all leaf types become <string>
+            let s = match val {
+                LLSDValue::Undefined => "",
+                LLSDValue::Boolean(v) => {
+                    if *v {
+                        "true"
+                    } else {
+                        "false"
+                    }
+                }
+                LLSDValue::String(v) => v.as_str(),
+                LLSDValue::Integer(v) => &v.to_string(),
+                LLSDValue::Real(v) => &v.to_string(),
+                LLSDValue::UUID(v) => &v.to_string(),
+                LLSDValue::Binary(v) => &base64::engine::general_purpose::STANDARD.encode(v),
+                LLSDValue::Date(v) => &v.to_string(),
+                _ => "",
+            };
+            tag_value(writer, s, indent, do_indent);
+        }
+    }
+}


### PR DESCRIPTION
Since opensimulator still uses xml-rpc for handling login information added this to the crate to allow moving to and from xml-rpc data.